### PR TITLE
On create, use db provided id only if not specified in the model

### DIFF
--- a/lib/sqlite3db.js
+++ b/lib/sqlite3db.js
@@ -830,7 +830,7 @@ SQLiteDB.prototype.create = function create(model, data, callback) {
       return callback(err);
     }
 
-    callback(err, lastUpdatedID);
+    callback(err, data[idColName] || lastUpdatedID);
   });
 };
 


### PR DESCRIPTION
This PR fixes a problem I've had using this connector on a model which specifies an id value to be used as primary key (i.e. id is not autogenerated by db). The original implementation always overwrites the id specified in the model with "lastUpdatedID" which is Sqlite3's ROWID value.
This causes problems in hooks, where an insert with a model specifying an id, results in an answer which contains a different id that cannot be used to work with the original model.

Consider this model definition:

```{
  "name": "sensor",
  "plural": "sensors",
  "base": "PersistedModel",
  "idInjection": false,
  "strict": true,
  "options": {
    "validateUpsert": true
  },
  "properties": {
    "id": {
      "type": "string",
      "id": true
    },
    "model": {
      "type": "string"
    }
  },
  "validations": [],
  "acls": [],
  "methods": []
}```

On create, if you specify:

```{ "id":"myuniqueid", "model":"some model" }```

the resulting data is:

```{ "id":1, "model":"some model" }```

But the problem is that id's value 1 cannot be used to work with the model since the effective id in the DB is "myuniqueid".

This PR returns the original id if present in the model, or "lastUpdatedID" if not present.
All tests pass.
