### PR TITLE
Fix for ALTER TABLE

### DIFF
--- a/lib/sqlite3db.js
+++ b/lib/sqlite3db.js
@@ -1033,8 +1033,8 @@ SQLiteDB.prototype.all = function all(model, filter, callback) {
         data_temp = reset_order(data);
         self.current_order = [];
       }
-
-      callback(null, (data_temp.length != 0) ? data_temp : data);
+      if (typeof(callback) === 'function')
+        callback(null, (data_temp.length != 0) ? data_temp : data);
     }
   }.bind(this));
 };

--- a/lib/sqlite3db.js
+++ b/lib/sqlite3db.js
@@ -354,7 +354,7 @@ function getAddModifyColumns(model, actualFields) {
 function getDropColumns(model, actualFields) {
   var sql = [];
   var self = this;
-  sql = sql.concat(getColumnsToDrop.call(self, model, actualFields));
+  // sql = sql.concat(getColumnsToDrop.call(self, model, actualFields));
   return sql;
 }
 
@@ -371,9 +371,6 @@ function getColumnsToAdd(model, actualFields) {
       sql.push('ADD COLUMN ' + addPropertyToActual.call(self, model, propName));
     }
   });
-  if (sql.length > 0) {
-    sql = [sql.join(', ')];
-  }
 
   return sql;
 }
@@ -507,7 +504,7 @@ function applySqlChanges(model, pendingChanges, cb) {
     var ranOnce = false;
     pendingChanges.forEach(function (change) {
       if (ranOnce) {
-        thisQuery = thisQuery + ' ';
+        thisQuery = thisQuery + '; ';
       }
       thisQuery = thisQuery + ' ' + change;
       ranOnce = true;

--- a/test/user_model.test.js
+++ b/test/user_model.test.js
@@ -53,4 +53,14 @@ describe("SQLite Model creation test", function(){
     }
   });
 
+  it('should run auto-migration when model changes', function (done) {
+    User = db.define('User', {
+      id: {type: Number, id: true},
+      new_name: { type: String }
+    });
+    db.automigrate('User', function () {
+      done();
+    });
+  });
+  
 });


### PR DESCRIPTION
SQLite ALTER TABLE does not support adding more than one colum at a
time; it also does not support dropping columns.