### PR TITLE
Fixed multiple alter tables, separating statements with ; does not work

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -298,19 +298,20 @@ function mixinMigration(SQLiteDB) {
   function applySqlChanges(model, pendingChanges, cb) {
     var self = this;
     if (pendingChanges.length) {
-      var thisQuery = 'ALTER TABLE ' + self.tableEscaped(model);
-      var ranOnce = false;
+      var changesPrefix = 'ALTER TABLE ' + self.tableEscaped(model);
+      var done = 0;
+      var globalRes = [];
       pendingChanges.forEach(function (change) {
-        if (ranOnce) {
-          thisQuery = thisQuery + '; ';
-        }
-        thisQuery = thisQuery + ' ' + change;
-        ranOnce = true;
+        self.query(changesPrefix + ' ' + change, function (err, res) {
+          globalRes.push(res);
+          if (++done === pendingChanges.length) {
+            cb && cb(err ? err : null, globalRes);
+          }
+        });
       });
-      // thisQuery = thisQuery + ';';
-      self.query(thisQuery, cb);
     }
   }
+
 
   /*!
    * Build a list of columns for the given model


### PR DESCRIPTION
I've altered a model in loopback requiring 2 columns to be added. The generated SQL was:

ALTER TABLE 'tb' ADD COLUMN 'col1'; ADD COLUMN 'col2'

This does not work as sqlite3 does not allow multiple columns to be added with a single alter table. Moreover, the node sqlite client does not allow for multiple statements to be separated by ';'.
This PR executes each "add column" as a separate queries.