### PR TITLE
Ensure date is not null when reading from database

### DIFF
--- a/lib/sqlite3db.js
+++ b/lib/sqlite3db.js
@@ -423,7 +423,7 @@ SQLiteDB.prototype.fromDatabase = function (model, data) {
       } else {
         json[p] = val;
       }
-    } else if (prop && type === 'Date'){
+    } else if (prop && (type === 'Date') && (val !== null)) {
       json[p] = new Date(val);
     } else {
       json[p] = val;


### PR DESCRIPTION
Added a check for NULL when getting a date value from the database. This ensures that NULL values aren't being returned as Jan 1, 1970.