### PR TITLE
fixing bug in dataSource.connector.dataSource.log

### DIFF
--- a/lib/sqlite3db.js
+++ b/lib/sqlite3db.js
@@ -26,9 +26,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   dataSource.connector = connector;
   dataSource.connector.dataSource = dataSource;
 
-  dataSource.connector.dataSource.log = function (msg) {
-   console.log(msg);
-  };
+  dataSource.connector.dataSource.log = console.log;
 
   if(callback){
     dataSource.connecting = true;


### PR DESCRIPTION
dataSource.connector.dataSource.log could only take one argument, while console.log() can take any number of arguments.
Thus log statements like log(sql, err) were not printing the error message.
Modified to set log = console.log;